### PR TITLE
Added VSS information to Get-DiskChanges (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
+This file contains all of the functions that IITS distributes to all managed services machines.  The current list of command available are:
 
-This file contains all of the functions that IITS distributes to all managed services machines. The current list of command available are:
 |Script|Author|
 |---|---|
 |Check-PSVersion|Antonio Vincentelli|
@@ -17,8 +17,8 @@ This file contains all of the functions that IITS distributes to all managed ser
 |Get-MailFlowStats|Darren Khan|
 |Get-Projection|Arjun Gheek|
 |Get-ServiceAccount|Darren Khan|
+|Get-VSSStatistics|Darren Khan|
 |Hide-User-From-GAL|Michael Surtees|
 |Remove-Application|Darren Khan|
 |Remove-Outlook-Automap|Michael Surtees|
 |Toggle-ActionCenter|Darren Khan|
-


### PR DESCRIPTION
* Updated Get-DiskStatistics

Function Get-DiskStatistics will now only return the fixed disks on the computer.  It will skip removable drives and cd drives.

* BugFixes in Get-DiskChanges

Changed line to out-null when creating a new folder.  No needed.  Cleaned up the help information in Get-DiskChanges and Get-DriveStatistics.  Added inline comment for comparison block in case someone wants to copy the code to make another comparison.

* Created Get-VSSStatistics

New function that returns the state of VSS snapshots upsed.

* Updated Get-VSSStatistics & Get-DiskChanges

Finished writing Get-VSSStatistics and all error handling as well as updating Get-DiskChanges to also account for Get-VSSStatistics.  Tested to make sure that files are working correctly in both admin and non admin powershell sessions.  Created all help files and updated readme.md.